### PR TITLE
Closes #1 Remove duplicate environment variable resolution code

### DIFF
--- a/__wip9/least_common_multiple.jl
+++ b/__wip9/least_common_multiple.jl
@@ -1,0 +1,33 @@
+"""
+    least_common_multiple(a::Int, b::Int)
+
+Finds the least common multiple of two integers
+
+# Arguments:
+- `a`: First of two integers
+- `b`: Second of two integers
+
+# Examples/Tests:
+```julia
+least_common_multiple(12, 76) # returns 228
+least_common_multiple(5, -10) # returns 10
+```
+
+# References:
+- https://en.wikipedia.org/wiki/Least_common_multiple 
+- https://www.javatpoint.com/python-find-lcm 
+"""
+
+function least_common_multiple(a::Int, b::Int)
+    if a >= b
+        common_multiple = a
+    else
+        common_multiple = b
+    end
+
+    while (common_multiple % a != 0) || (common_multiple % b != 0)
+        common_multiple += 1
+    end
+
+    return common_multiple
+end

--- a/__wip9/problem_010.jl
+++ b/__wip9/problem_010.jl
@@ -1,0 +1,27 @@
+"""
+    Summation of primes
+
+The sum of the primes below 10 is 2 + 3 + 5 + 7 = 17.
+
+Find the sum of all the primes below two million.
+
+# Input parameters:
+- `n` : Upper limit of primes.
+
+# Examples/Tests:
+```julia
+problem_010(1)          # returns 0
+problem_010(10)         # returns 17
+problem_010(2000000)    # returns 142913828922
+problem_010(-1)         # throws DomainError
+```
+
+# Reference
+- https://projecteuler.net/problem=10
+
+Contributed by: [Praneeth Jain](https://www.github.com/PraneethJain)
+"""
+function problem_010(n::Int)
+    n < 1 && throw(DomainError("n must be a natural number"))
+    return reduce(+, eratosthenes(Int64(n)), init = Int64(0))
+end

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ✨ clean.sh — HYPERGLAM repo detox (macOS + Python) ✨
+# Usage:
+#   DRY_RUN=1 ./clean.sh    # preview
+#   ./clean.sh              # actually delete
+#
+# Notes:
+# - Safe-ish: skips .git and never touches outside project root.
+# - Fixes your main bug: rmrf isn't visible inside `find -exec bash -c ...` subshells.
+
+set -Eeuo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+FIND_ROOT="."
+
+say()  { printf '%b\n' "$*"; }
+ok()   { say "✅ $*"; }
+info() { say "✨ $*"; }
+warn() { say "⚠️  $*"; }
+
+rmrf() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '🧹 (dry-run) rm -rf %q\n' "$@"
+  else
+    printf '🧹 rm -rf %q\n' "$@"
+    rm -rf -- "$@"
+  fi
+}
+
+# Delete files (via find) with glam output + dry-run support
+find_del_files() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    # print what would be deleted
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -f /'
+  else
+    # print then delete (portable: no -delete surprises)
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type f "$@" -print -exec rm -f -- {} + 2>/dev/null
+  fi
+}
+
+# Delete directories (via find) with glam output + dry-run support
+find_del_dirs() {
+  local root="$1"; shift
+  if [[ ! -e "$root" ]]; then
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print 2>/dev/null \
+      | sed 's/^/🧹 (dry-run) rm -rf /'
+  else
+    # Use -prune + -exec rm -rf to reliably delete matching dirs
+    find "$root" -path "./.git" -prune -o -path "./.git/*" -prune -o \
+      -type d "$@" -print -prune -exec rm -rf -- {} + 2>/dev/null
+  fi
+}
+
+info "Cleaning up Python project clutter… (DRY_RUN=$DRY_RUN)"
+
+# --- Python bytecode & caches -------------------------------------------------
+info "Bytecode & caches"
+find_del_dirs "$FIND_ROOT" -name "__pycache__"
+find_del_files "$FIND_ROOT" \( -name "*.py[co]" -o -name "*.pyd" \)
+
+# --- build/dist/egg-info ------------------------------------------------------
+info "Build artifacts"
+for d in ./build ./dist ./docs/_build ./__pypackages__ ./pip-wheel-metadata; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+find_del_dirs "$FIND_ROOT" -name "*.egg-info"
+
+# --- test & typing caches -----------------------------------------------------
+info "Test/typing caches"
+for d in ./.pytest_cache ./.mypy_cache ./.ruff_cache ./htmlcov; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+# .coverage can be a file OR a dir; handle both
+[[ -e ./.coverage ]] && rmrf ./.coverage
+find_del_files "$FIND_ROOT" \( -name ".coverage" -o -name ".coverage.*" \)
+
+# --- virtual envs / env caches (optional) ------------------------------------
+info "Virtual envs / caches (optional)"
+for d in ./.venv ./.tox ./.nox ./.cache; do
+  [[ -e "$d" ]] && rmrf "$d"
+done
+
+# --- Jupyter checkpoints ------------------------------------------------------
+info "Jupyter checkpoints"
+find_del_dirs "$FIND_ROOT" -name ".ipynb_checkpoints"
+
+# --- Sphinx doctrees ----------------------------------------------------------
+info "Sphinx doctrees"
+find_del_dirs ./docs -name ".doctrees"
+find_del_files ./docs -name "*.doctree"
+
+# --- OS cruft -----------------------------------------------------------------
+info "OS cruft"
+find_del_files "$FIND_ROOT" -name ".DS_Store"
+find_del_files "$FIND_ROOT" -name "Thumbs.db"
+find_del_files "$FIND_ROOT" -name "._*"
+find_del_dirs  "$FIND_ROOT" -name ".Trashes"
+
+# --- backup/editor swap files -------------------------------------------------
+info "Backup/swap files"
+find_del_files "$FIND_ROOT" \( -name "*~" -o -name "*.swp" -o -name "*.bak" \)
+
+# --- compiled extensions (optional) ------------------------------------------
+info "Compiled extensions (optional)"
+find_del_files "$FIND_ROOT" -name "*.so"
+
+ok "Everything Done Under the Sun."


### PR DESCRIPTION
1 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.