### PR TITLE
Closes #71 Implement: Add Bayesian-inference peer review feedback to core logic

### DIFF
--- a/__sql2/InsertionSortTest.java
+++ b/__sql2/InsertionSortTest.java
@@ -1,0 +1,198 @@
+package com.thealgorithms.sorts;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InsertionSortTest {
+    private InsertionSort insertionSort;
+
+    @BeforeEach
+    void setUp() {
+        insertionSort = new InsertionSort();
+    }
+
+    @Test
+    void insertionSortSortEmptyArrayShouldPass() {
+        testEmptyArray(insertionSort::sort);
+        testEmptyArray(insertionSort::sentinelSort);
+    }
+
+    private void testEmptyArray(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalSortSingleValueArrayShouldPass() {
+        testSingleValue(insertionSort::sort);
+        testSingleValue(insertionSort::sentinelSort);
+    }
+
+    private void testSingleValue(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {7};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {7};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithIntegerArrayShouldPass() {
+        testIntegerArray(insertionSort::sort);
+        testIntegerArray(insertionSort::sentinelSort);
+    }
+
+    private void testIntegerArray(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {49, 4, 36, 9, 144, 1};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {1, 4, 9, 36, 49, 144};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalForArrayWithNegativeValuesShouldPass() {
+        testWithNegativeValues(insertionSort::sort);
+        testWithNegativeValues(insertionSort::sentinelSort);
+    }
+
+    private void testWithNegativeValues(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {49, -36, -144, -49, 1, 9};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {-144, -49, -36, 1, 9, 49};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalForArrayWithDuplicateValuesShouldPass() {
+        testWithDuplicates(insertionSort::sort);
+        testWithDuplicates(insertionSort::sentinelSort);
+    }
+
+    private void testWithDuplicates(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {36, 1, 49, 1, 4, 9};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {1, 1, 4, 9, 36, 49};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithStringArrayShouldPass() {
+        testWithStringArray(insertionSort::sort);
+        testWithStringArray(insertionSort::sentinelSort);
+    }
+
+    private void testWithStringArray(Function<String[], String[]> sortAlgorithm) {
+        String[] array = {"c", "a", "e", "b", "d"};
+        String[] sorted = sortAlgorithm.apply(array);
+        String[] expected = {"a", "b", "c", "d", "e"};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithRandomArrayPass() {
+        testWithRandomArray(insertionSort::sort);
+        testWithRandomArray(insertionSort::sentinelSort);
+    }
+
+    private void testWithRandomArray(Function<Double[], Double[]> sortAlgorithm) {
+        int randomSize = SortUtilsRandomGenerator.generateInt(10_000);
+        Double[] array = SortUtilsRandomGenerator.generateArray(randomSize);
+        Double[] sorted = sortAlgorithm.apply(array);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    public void testSortAlreadySortedArray() {
+        Integer[] inputArray = {-12, -6, -3, 0, 2, 2, 13, 46};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {-12, -6, -3, 0, 2, 2, 13, 46};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortReversedSortedArray() {
+        Integer[] inputArray = {46, 13, 2, 2, 0, -3, -6, -12};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {-12, -6, -3, 0, 2, 2, 13, 46};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortAllEqualArray() {
+        Integer[] inputArray = {2, 2, 2, 2, 2};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {2, 2, 2, 2, 2};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortMixedCaseStrings() {
+        String[] inputArray = {"banana", "Apple", "apple", "Banana"};
+        String[] expectedOutput = {"Apple", "Banana", "apple", "banana"};
+        String[] outputArray = insertionSort.sort(inputArray);
+        assertArrayEquals(expectedOutput, outputArray);
+    }
+
+    /**
+     * Custom Comparable class for testing.
+     **/
+    static class Person implements Comparable<Person> {
+        String name;
+        int age;
+
+        Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        @Override
+        public int compareTo(Person o) {
+            return Integer.compare(this.age, o.age);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Person person = (Person) o;
+            return age == person.age && Objects.equals(name, person.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, age);
+        }
+    }
+
+    @Test
+    public void testSortCustomObjects() {
+        Person[] inputArray = {
+            new Person("Alice", 32),
+            new Person("Bob", 25),
+            new Person("Charlie", 28),
+        };
+        Person[] expectedOutput = {
+            new Person("Bob", 25),
+            new Person("Charlie", 28),
+            new Person("Alice", 32),
+        };
+        Person[] outputArray = insertionSort.sort(inputArray);
+        assertArrayEquals(expectedOutput, outputArray);
+    }
+}

--- a/__sql2/Kosaraju.cs
+++ b/__sql2/Kosaraju.cs
@@ -1,0 +1,124 @@
+using DataStructures.Graph;
+
+namespace Algorithms.Graph;
+
+/// <summary>
+/// Implementation of Kosaraju-Sharir's algorithm (also known as Kosaraju's algorithm) to find the
+/// strongly connected components (SCC) of a directed graph.
+/// See https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm.
+/// </summary>
+/// <typeparam name="T">Vertex data type.</typeparam>
+public static class Kosaraju<T>
+{
+    /// <summary>
+    /// First DFS for Kosaraju algorithm: traverse the graph creating a reverse order explore list <paramref name="reversed"/>.
+    /// </summary>
+    /// <param name="v">Vertex to explore.</param>
+    /// <param name="graph">Graph instance.</param>
+    /// <param name="visited">List of already visited vertex.</param>
+    /// <param name="reversed">Reversed list of vertex for the second DFS.</param>
+    public static void Visit(Vertex<T> v, IDirectedWeightedGraph<T> graph, HashSet<Vertex<T>> visited, Stack<Vertex<T>> reversed)
+    {
+        if (visited.Contains(v))
+        {
+            return;
+        }
+
+        // Set v as visited
+        visited.Add(v);
+
+        // Push v in the stack.
+        // This can also be done with a List, inserting v at the begining of the list
+        // after visit the neighbors.
+        reversed.Push(v);
+
+        // Visit neighbors
+        foreach (var u in graph.GetNeighbors(v))
+        {
+            Visit(u!, graph, visited, reversed);
+        }
+    }
+
+    /// <summary>
+    /// Second DFS for Kosaraju algorithm. Traverse the graph in reversed order
+    /// assigning a root vertex for every vertex that belong to the same SCC.
+    /// </summary>
+    /// <param name="v">Vertex to assign.</param>
+    /// <param name="root">Root vertext, representative of the SCC.</param>
+    /// <param name="graph">Graph with vertex and edges.</param>
+    /// <param name="roots">
+    /// Dictionary that assigns to each vertex the root of the SCC to which it corresponds.
+    /// </param>
+    public static void Assign(Vertex<T> v, Vertex<T> root, IDirectedWeightedGraph<T> graph, Dictionary<Vertex<T>, Vertex<T>> roots)
+    {
+        // If v already has a representative vertex (root) already assigned, do nothing.
+        if (roots.ContainsKey(v))
+        {
+            return;
+        }
+
+        // Assign the root to the vertex.
+        roots.Add(v, root);
+
+        // Assign the current root vertex to v neighbors.
+        foreach (var u in graph.GetNeighbors(v))
+        {
+            Assign(u!, root, graph, roots);
+        }
+    }
+
+    /// <summary>
+    /// Find the representative vertex of the SCC for each vertex on the graph.
+    /// </summary>
+    /// <param name="graph">Graph to explore.</param>
+    /// <returns>A dictionary that assigns to each vertex a root vertex of the SCC they belong. </returns>
+    public static Dictionary<Vertex<T>, Vertex<T>> GetRepresentatives(IDirectedWeightedGraph<T> graph)
+    {
+        HashSet<Vertex<T>> visited = [];
+        Stack<Vertex<T>> reversedL = new Stack<Vertex<T>>();
+        Dictionary<Vertex<T>, Vertex<T>> representatives = [];
+
+        foreach (var v in graph.Vertices)
+        {
+            if (v != null)
+            {
+                Visit(v, graph, visited, reversedL);
+            }
+        }
+
+        visited.Clear();
+
+        while (reversedL.Count > 0)
+        {
+            Vertex<T> v = reversedL.Pop();
+            Assign(v, v, graph, representatives);
+        }
+
+        return representatives;
+    }
+
+    /// <summary>
+    /// Get the Strongly Connected Components for the graph.
+    /// </summary>
+    /// <param name="graph">Graph to explore.</param>
+    /// <returns>An array of SCC.</returns>
+    public static IEnumerable<Vertex<T>>[] GetScc(IDirectedWeightedGraph<T> graph)
+    {
+        var representatives = GetRepresentatives(graph);
+        Dictionary<Vertex<T>, List<Vertex<T>>> scc = [];
+        foreach (var kv in representatives)
+        {
+            // Assign all vertex (key) that have the seem root (value) to a single list.
+            if (scc.ContainsKey(kv.Value))
+            {
+                scc[kv.Value].Add(kv.Key);
+            }
+            else
+            {
+                scc.Add(kv.Value, [kv.Key]);
+            }
+        }
+
+        return scc.Values.ToArray();
+    }
+}

--- a/__sql2/heap.rs
+++ b/__sql2/heap.rs
@@ -1,0 +1,66 @@
+use std::fmt::Debug;
+
+/// Computes all permutations of an array using Heap's algorithm
+/// Read `recurse_naive` first, since we're building on top of the same intuition
+pub fn heap_permute<T: Clone + Debug>(arr: &[T]) -> Vec<Vec<T>> {
+    if arr.is_empty() {
+        return vec![vec![]];
+    }
+    let n = arr.len();
+    let mut collector = Vec::with_capacity((1..=n).product()); // collects the permuted arrays
+    let mut arr = arr.to_owned(); // Heap's algorithm needs to mutate the array
+    heap_recurse(&mut arr, n, &mut collector);
+    collector
+}
+
+fn heap_recurse<T: Clone + Debug>(arr: &mut [T], k: usize, collector: &mut Vec<Vec<T>>) {
+    if k == 1 {
+        // same base-case as in the naive version
+        collector.push((*arr).to_owned());
+        return;
+    }
+    // Remember the naive recursion. We did the following: swap(i, last), recurse, swap back(i, last)
+    // Heap's algorithm has a more clever way of permuting the elements so that we never need to swap back!
+    for i in 0..k {
+        // now deal with [a, b]
+        let swap_idx = if k.is_multiple_of(2) { i } else { 0 };
+        arr.swap(swap_idx, k - 1);
+        heap_recurse(arr, k - 1, collector);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    use crate::general::permutations::heap_permute;
+    use crate::general::permutations::tests::{
+        assert_permutations, assert_valid_permutation, NotTooBigVec,
+    };
+
+    #[test]
+    fn test_3_different_values() {
+        let original = vec![1, 2, 3];
+        let res = heap_permute(&original);
+        assert_eq!(res.len(), 6); // 3!
+        for permut in res {
+            assert_valid_permutation(&original, &permut)
+        }
+    }
+
+    #[test]
+    fn test_3_times_the_same_value() {
+        let original = vec![1, 1, 1];
+        let res = heap_permute(&original);
+        assert_eq!(res.len(), 6); // 3!
+        for permut in res {
+            assert_valid_permutation(&original, &permut)
+        }
+    }
+
+    #[quickcheck]
+    fn test_some_elements(NotTooBigVec { inner: original }: NotTooBigVec) {
+        let permutations = heap_permute(&original);
+        assert_permutations(&original, &permutations)
+    }
+}

--- a/__sql2/jump_search.ts
+++ b/__sql2/jump_search.ts
@@ -1,0 +1,46 @@
+/**
+ * @function jumpSearch
+ * @description Jump search algorithm for a sorted array.
+ *
+ * Jump search is a searching algorithm for sorted arrays that checks elements
+ * by jumping ahead by fixed steps. The optimal step size is the square root of the array length.
+ *
+ * The algorithm works as follows:
+ * 1.Start from the first element and jump by step size until finding an element that is greater than or equal to the target value.
+ * 2.Go back one step and perform a linear search from there until finding the target value or reaching the end of the subarray.
+ * 3.If the target value is found, return its index. Otherwise, return -1 to indicate that it is not in the array.
+ *
+ * @param {number[]} array - sorted list of numbers
+ * @param {number} target - target number to search for
+ * @return {number} - index of the target number in the list, or -1 if not found
+ * @see [JumpSearch](https://www.geeksforgeeks.org/jump-search/)
+ * @example jumpSearch([1,2,3], 2) => 1
+ * @example jumpSearch([4,5,6], 2) => -1
+ */
+
+export const jumpSearch = (array: number[], target: number): number => {
+  if (array.length === 0) return -1
+
+  // declare pointers for the current and next indexes and step size
+  const stepSize: number = Math.floor(Math.sqrt(array.length))
+  let currentIdx: number = 0,
+    nextIdx: number = stepSize
+
+  while (array[nextIdx - 1] < target) {
+    currentIdx = nextIdx
+    nextIdx += stepSize
+
+    if (nextIdx > array.length) {
+      nextIdx = array.length
+      break
+    }
+  }
+
+  for (let index = currentIdx; index < nextIdx; index++) {
+    if (array[index] == target) {
+      return index
+    }
+  }
+
+  return -1
+}

--- a/__sql2/problem16_test.go
+++ b/__sql2/problem16_test.go
@@ -1,0 +1,30 @@
+package problem16
+
+import "testing"
+
+// Tests
+func TestProblem16_Func(t *testing.T) {
+	tests := []struct {
+		name     string
+		exponent int64
+		want     int64
+	}{
+		{"2^15", 15, 26},
+		{"2^1000", 1000, 1366},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Problem16(tt.exponent); got != tt.want {
+				t.Errorf("Problem16() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Benchmark
+func BenchmarkProblem16_Func(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Problem16(1000)
+	}
+}


### PR DESCRIPTION
71 Closing this as it is a duplicate of the divergent loss issue reported in #402. The stabilization logic was merged in the previous sprint, making this redundant. Discussion regarding RNA-velocity estimation should remain centralized in the original thread to maintain a clean audit trail.